### PR TITLE
Remove URL_PREFIX and cleanup settings

### DIFF
--- a/src/pycontw2016/settings/base.py
+++ b/src/pycontw2016/settings/base.py
@@ -8,11 +8,12 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
-from os.path import dirname, join, exists
+from os.path import abspath, dirname, join, exists
+from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 # Build paths inside the project like this: join(BASE_DIR, "directory")
-BASE_DIR = dirname(dirname(dirname(__file__)))
+BASE_DIR = dirname(dirname(dirname(abspath(__file__))))
 
 # Use Django templates using the new Django 1.8 TEMPLATES settings
 TEMPLATES = [
@@ -60,6 +61,15 @@ SECRET_KEY = env('SECRET_KEY')
 
 ALLOWED_HOSTS = []
 
+# Database
+# https://docs.djangoproject.com/en/dev/ref/settings/#databases
+
+DATABASES = {
+    # Raises ImproperlyConfigured exception if DATABASE_URL not in
+    # os.environ
+    'default': env.db(),
+}
+
 # Application definition
 
 DJANGO_APPS = (
@@ -85,6 +95,11 @@ LOCAL_APPS = (
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
+# Enable Postgres-specific things if we are using it.
+if 'postgres' in DATABASES['default']['ENGINE']:
+    INSTALLED_APPS += ('postgres',)
+
+
 MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -101,17 +116,13 @@ ROOT_URLCONF = 'pycontw2016.urls'
 
 WSGI_APPLICATION = 'pycontw2016.wsgi.application'
 
-# Database
-# https://docs.djangoproject.com/en/dev/ref/settings/#databases
-
-DATABASES = {
-    # Raises ImproperlyConfigured exception if DATABASE_URL not in
-    # os.environ
-    'default': env.db(),
-}
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
+
+USE_I18N = True
+
+USE_L10N = True
 
 LANGUAGE_CODE = 'en-us'
 
@@ -120,13 +131,15 @@ LANGUAGES = [
     ('en', _('English')),
 ]
 
-TIME_ZONE = 'UTC'
-
-USE_I18N = True
-
-USE_L10N = True
+# Path to the local .po and .mo files
+LOCALE_PATHS = (
+    join(BASE_DIR, 'locale'),
+)
 
 USE_TZ = True
+
+TIME_ZONE = 'UTC'
+
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/dev/howto/static-files/
@@ -137,17 +150,17 @@ STATIC_ROOT = join(BASE_DIR, 'assets')
 
 STATICFILES_DIRS = [join(BASE_DIR, 'static')]
 
+
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://example.com/media/", "http://media.example.com/"
 
 MEDIA_ROOT = join(BASE_DIR, 'media')
 
-MEDIA_URL = "/media/"
-
-ALLOWED_HOSTS = []
+MEDIA_URL = '/media/'
 
 LIBSASS_SOURCEMAPS = True
+
 
 # List of finder classes that know how to find static files in
 # various locations.
@@ -157,24 +170,24 @@ STATICFILES_FINDERS = (
     'compressor.finders.CompressorFinder',
 )
 
+
+# URL settings.
+
+LOGIN_URL = reverse_lazy('login')
+
+LOGOUT_URL = reverse_lazy('logout')
+
+LOGIN_REDIRECT_URL = reverse_lazy('user_dashboard')
+
+
+# Third-party app and custom settings.
+
+AUTH_USER_MODEL = 'users.User'
+
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
 )
 
-AUTH_USER_MODEL = 'users.User'
-
-URL_PREFIX = None
-
-LOGIN_REDIRECT_URL = '/dashboard/'
-
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
 WERKZEUG_DEBUG = env.bool('WERKZEUG_DEBUG', default=True)
-
-
-# Translation settings
-# Path to the local .po and .mo files
-
-LOCALE_PATHS = (
-    join(BASE_DIR, 'locale'),
-)

--- a/src/pycontw2016/settings/local.py
+++ b/src/pycontw2016/settings/local.py
@@ -7,15 +7,11 @@ DEBUG = True
 
 # Turn off debug while imported by Celery with a workaround
 # See http://stackoverflow.com/a/4806384
-if "celery" in sys.argv[0]:
+if 'celery' in sys.argv[0]:
     DEBUG = False
 
 # Django Debug Toolbar
 INSTALLED_APPS += ('debug_toolbar.apps.DebugToolbarConfig',)
-
-# Postgres-specifi migrations
-if 'postgres' in DATABASES['default']['ENGINE']:
-    INSTALLED_APPS += ('postgres',)
 
 # Show emails to console in DEBUG mode
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/src/pycontw2016/settings/production.py
+++ b/src/pycontw2016/settings/production.py
@@ -6,10 +6,13 @@ import logging.config
 # For security and performance reasons, DEBUG is turned off
 DEBUG = False
 
-INSTALLED_APPS += ('postgres',)
-
 # Must mention ALLOWED_HOSTS in production!
-ALLOWED_HOSTS = ["pycontw.krdai.info", "tw.pycon.org"]
+ALLOWED_HOSTS = ['pycontw.krdai.info', 'tw.pycon.org']
+
+# Override static and media URL for prefix in WSGI server.
+# https://code.djangoproject.com/ticket/25598
+STATIC_URL = '/2016/static/'
+MEDIA_URL = '/2016/media/'
 
 # Cache the templates in memory for speed-up
 loaders = [
@@ -25,9 +28,6 @@ loaders = [
 TEMPLATES[0]['OPTIONS'].update({"loaders": loaders})
 TEMPLATES[0]['OPTIONS'].update({"debug": False})
 del TEMPLATES[0]['APP_DIRS']
-
-# Define STATIC_ROOT for the collectstatic command
-STATIC_ROOT = join(BASE_DIR, 'assets')
 
 # Log everything to the logs directory at the top
 LOGFILE_ROOT = join(dirname(BASE_DIR), 'logs')
@@ -83,16 +83,6 @@ LOGGING = {
 
 logging.config.dictConfig(LOGGING)
 
-URL_PREFIX = '2016/'
-
-LOGIN_URL = '/2016/accounts/login/'
-
-LOGOUT_URL = '/2016/accounts/logout/'
-
-LOGIN_REDIRECT_URL = '/2016/dashboard/'
-
-STATIC_URL = '/2016/static/'
-
 EMAIL_BACKEND = env.email_url()['EMAIL_BACKEND']
 EMAIL_HOST = env.email_url()['EMAIL_HOST']
 EMAIL_HOST_PASSWORD = env.email_url()['EMAIL_HOST_PASSWORD']
@@ -117,7 +107,7 @@ INSTALLED_APPS += (
     'raven.contrib.django.raven_compat',
 )
 
-import raven
+import raven    # NOQA
 
 RAVEN_CONFIG = {
     'dsn': env('DSN_URL'),

--- a/src/pycontw2016/urls.py
+++ b/src/pycontw2016/urls.py
@@ -20,20 +20,8 @@ urlpatterns = [
     url(r'^i18n/', include('django.conf.urls.i18n')),
 ]
 
-if settings.URL_PREFIX:
-    urlpatterns = [
-        url(r'^{prefix}'.format(prefix=settings.URL_PREFIX),
-            include(urlpatterns)),
-    ]
-
 # User-uploaded files like profile pics need to be served in development
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # Catch-all URL pattern must be put last.
-if settings.URL_PREFIX:
-    urlpatterns += [
-        url(r'^{prefix}(?P<path>.+)/$'.format(prefix=settings.URL_PREFIX),
-            flat_page, name='page'),
-    ]
-else:
-    urlpatterns += [url(r'^(?P<path>.+)/$', flat_page, name='page')]
+urlpatterns += [url(r'^(?P<path>.+)/$', flat_page, name='page')]


### PR DESCRIPTION
Site-wide path prefix (i.e. WSGI mount point) will now be
controlled in the WSGI server via the SCRIPT_NAME variable.
The project will not take it into account.