### PR TITLE
修正 dashboard 細節

### DIFF
--- a/src/static/css/main.scss
+++ b/src/static/css/main.scss
@@ -31,6 +31,10 @@ body {
     border: none;
 }
 
+.text-middle {
+    vertical-align: middle;
+}
+
 .top-nav {
     background-color: $theme-color;
     padding: 24px 44px;

--- a/src/static/css/themes/_proposals.scss
+++ b/src/static/css/themes/_proposals.scss
@@ -183,8 +183,11 @@ body.dashboard{
 }
 
 .bio_field {
-    width: 600px;
-    height: 154px;
+    min-width: 600px;
+    max-width: 600px;
+    min-height: 154px;
+    max-height: 154px;
+    font-family: $font-family-monospace;
 }
 
 .save-btn {

--- a/src/templates/dashboard_base.html
+++ b/src/templates/dashboard_base.html
@@ -14,18 +14,18 @@
 {% if not user.verified %}
 <div class="row">
   <div class="alert alert-warning clearfix" role="alert">
-    <p>{% trans 'You need to verify your email before being able to submit a proposal.' %}</p>
+    <p>{% trans 'Please verify your account by clicking the link in the mail we sent to your email inbox.' %}</p>
     <form method="post" action="{% url 'request_verification' %}" class="form form-inline">
       {% csrf_token %}
-      <p>{% trans 'Did not get the verification email?' %}</p>
-      <button type="submit" class="btn btn-link">{% trans 'Request a new one.' %}</button>
+      <p><span class="text-middle">{% trans 'Did not get the verification mail?' %}</span>
+      <button type="submit" class="btn btn-link">{% trans 'Request a new one.' %}</button></p>
     </form>
   </div>
 </div>
 {% elif not user.is_valid_speaker %}
 <div class="row">
   <div class="alert alert-warning clearfix" role="alert">
-    <p>{% trans 'Please complete your speaker profile before submitting a proposal.' %}</p>
+    <p>{% trans 'You need to complete your speaker profile first before submitting a proposal.' %}</p>
   </div>
 </div>
 {% endif %}

--- a/src/templates/users/user_dashboard.html
+++ b/src/templates/users/user_dashboard.html
@@ -8,26 +8,29 @@
 
 {% if user.is_valid_speaker %}
 
+	{% url 'talk_proposal_create' as talk_proposal_create_url %}
+	{% url 'tutorial_proposal_create' as tutorial_proposal_create_url %}
+
 	<div class="talk-proposals proposals">
     <div class="page-header">
-        <h3>{% trans 'Talk Proposals' %} <a href="{% url 'talk_proposal_create' %}" class="btn new-btn hidden-xs" role="button"><i class="fa fa-plus"></i>&nbsp;{% trans 'New Talk Porposal' %}</a><a href="{% url 'talk_proposal_create' %}" class="btn new-btn visible-xs-inline" role="button"><i class="fa fa-plus"></i></a></h3>
+        <h3>{% trans 'Talk Proposals' %} <a href="{% url 'talk_proposal_create' %}" class="btn new-btn hidden-xs" role="button"><i class="fa fa-plus"></i>&nbsp;{% trans 'New Talk Porposal' %}</a><a href="{{ talk_proposal_create_url }}" class="btn new-btn visible-xs-inline" role="button"><i class="fa fa-plus"></i></a></h3>
     </div>
 
     {% if user.talkproposal_set.exists %}
       {% include 'users/_includes/dashboard_proposal_table.html' with user=user proposals=user.talkproposal_set.all %}
     {% else %}
-      <p>{% blocktrans %}You haven't submitted any talk proposals yet.{% endblocktrans %}</p>
+      <p>{% blocktrans %}You haven't submitted any talk proposals. Why not <a href="{{ talk_proposal_create_url }}">submit one now</a>?{% endblocktrans %}</p>
     {% endif %}
 	</div>
 
   <div class="tutorial-proposals proposals">
     <div class="page-header">
-        <h3>{% trans 'Tutorial Proposals' %} <a href="{% url 'tutorial_proposal_create' %}" class="btn new-btn yellow-btn hidden-xs" role="button"><i class="fa fa-plus"></i>&nbsp;{% trans 'New Tutorial Porposal' %}</a><a href="{% url 'tutorial_proposal_create' %}" class="btn new-btn yellow-btn visible-xs-inline" role="button"><i class="fa fa-plus"></i></a></h3>
+        <h3>{% trans 'Tutorial Proposals' %} <a href="{% url 'tutorial_proposal_create' %}" class="btn new-btn yellow-btn hidden-xs" role="button"><i class="fa fa-plus"></i>&nbsp;{% trans 'New Tutorial Porposal' %}</a><a href="{{ tutorial_proposal_create_url }}" class="btn new-btn yellow-btn visible-xs-inline" role="button"><i class="fa fa-plus"></i></a></h3>
     </div>
     {% if user.tutorialproposal_set.exists %}
       {% include 'users/_includes/dashboard_proposal_table.html' with user=user proposals=user.tutorialproposal_set.all only %}
     {% else %}
-      <p>{% blocktrans %}You haven't submitted any tutorial proposals yet.{% endblocktrans %}</p>
+      <p>{% blocktrans %}You haven't submitted any talk proposals. Why not <a href="{{ tutorial_proposal_create_url }}">submit one now</a>?{% endblocktrans %}</p>
     {% endif %}
   </div>
 {% endif %}

--- a/src/templates/users/user_profile_update.html
+++ b/src/templates/users/user_profile_update.html
@@ -27,7 +27,7 @@
 	    		<input id="id_photo" name="photo" type="file" />
 	    	</div>
 	    </div>
-	    <p class="help-block">{% trans 'Suggested Dimensions: 800x800px or higher ' %}</p>
+	    <p class="help-block">{% trans 'At least 800&times;800 pixels for best results in our printed conference booklet.' %}</p>
 	</div>
 	<div class="form-group">
 		{{ form.speaker_name.errors }}
@@ -36,8 +36,8 @@
 	</div>
 	<div class="form-group">
 	    {{ form.bio.errors }}
-	    <label for="{{ form.bio.id_for_label }}" class="field_title">{% trans 'Self-Introduction' %}</label>
-	    <input id="id_bio" name="bio" type="text" class="form-control field bio_field" value="{{ form.bio.value }}">
+	    <label for="{{ form.bio.id_for_label }}" class="field_title">{% trans 'Biography' %}</label>
+	    <textarea id="id_bio" name="bio" class="form-control field bio_field">{{ form.bio.value }}</textarea>
 	    <p class="help-block">{% trans form.bio.help_text %}</p>
 	</div>
 

--- a/src/users/forms.py
+++ b/src/users/forms.py
@@ -46,7 +46,9 @@ class UserCreationForm(forms.ModelForm):
                 Field('password2', placeholder=self.fields['password2'].label),
             ),
             FormActions(
-                Submit('save', _('Create Account'), css_class='btn-lg btn-block')
+                Submit(
+                    'save', _('Create Account'), css_class='btn-lg btn-block',
+                )
             )
         )
 
@@ -171,13 +173,15 @@ class AuthenticationForm(BaseAuthenticationForm):
                 Field('username', placeholder=self.fields['username'].label),
                 Field('password', placeholder=self.fields['password'].label),
             ),
-            FormActions(
+            FormActions(Div(
                 Div(
-                    Div(HTML('''<a class="btn btn-link">{btn_text}</a>'''.format(
-                             btn_text=_('Forget Password?'))), css_class='col-xs-6 m-t-2'),
-                    Div(Submit('save', _('Log In'), css_class='btn-lg btn-block'),
-                        css_class='col-xs-6'),
-                    css_class='row'
-                    )
-            )
+                    HTML(_('<a class="btn btn-link">Forget Password?</a>')),
+                    css_class='col-xs-6 m-t-2',
+                ),
+                Div(
+                    Submit('save', _('Log In'), css_class='btn-lg btn-block'),
+                    css_class='col-xs-6',
+                ),
+                css_class='row',
+            ))
         )

--- a/src/users/tests/test_views_dashboard.py
+++ b/src/users/tests/test_views_dashboard.py
@@ -25,9 +25,30 @@ def test_dashboard_nologin(client):
     ]
 
 
-def test_dashboard_bare(bare_user_client):
-    response = bare_user_client.get('/en-us/dashboard/')
-    assert response.status_code == 200
+def test_dashboard_bare_unverified(bare_user_client):
+    """Bare user should be redirected to profile update page.
+    """
+    response = bare_user_client.get('/en-us/dashboard/', follow=True)
+    assert response.redirect_chain == [('/en-us/accounts/profile/', 302)]
+
+
+def test_dashboard_bare_verified(bare_user, bare_user_client):
+    """User without a valid profile should be redirected to profile page.
+    """
+    bare_user.verified = True
+    bare_user.save()
+    response = bare_user_client.get('/en-us/dashboard/', follow=True)
+    assert response.redirect_chain == [('/en-us/accounts/profile/', 302)]
+
+
+def test_dashboard_bare(bare_user, bare_user_client):
+    """Unverified user should be redirected to profile page.
+    """
+    bare_user.speaker_name = 'Bare User'
+    bare_user.bio = 'Wristwatch camera market vinyl rain shrine.'
+    bare_user.save()
+    response = bare_user_client.get('/en-us/dashboard/', follow=True)
+    assert response.redirect_chain == [('/en-us/accounts/profile/', 302)]
 
 
 @pytest.mark.xfail

--- a/src/users/tests/test_views_signup.py
+++ b/src/users/tests/test_views_signup.py
@@ -17,7 +17,7 @@ def test_signup_login(bare_user_client):
     redirect it to the dashboard.
     """
     response = bare_user_client.get('/en-us/accounts/signup/', follow=True)
-    assert response.redirect_chain == [('/en-us/dashboard/', 302)]
+    assert response.redirect_chain[0] == ('/en-us/dashboard/', 302)
 
 
 def test_signup_get(client):
@@ -42,7 +42,7 @@ def test_signup_post(client, parser):
         'password1': '7K50M',
         'password2': '7K50M',
     }, follow=True)
-    assert response.redirect_chain == [('/en-us/dashboard/', 302)]
+    assert response.redirect_chain[0] == ('/en-us/dashboard/', 302)
 
     msgs = [(m.level, m.message) for m in response.context['messages']]
     assert msgs == [
@@ -108,7 +108,7 @@ def test_verify(bare_user, bare_user_client):
     link = '/en-us/accounts/verify/{key}/'.format(key=key)
 
     response = bare_user_client.get(link, follow=True)
-    assert response.redirect_chain == [('/en-us/dashboard/', 302)]
+    assert response.redirect_chain[0] == ('/en-us/dashboard/', 302)
 
     msgs = [(m.level, m.message) for m in response.context['messages']]
     assert msgs == [

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -67,6 +67,8 @@ def request_verification(request):
 
 @login_required
 def user_dashboard(request):
+    if not request.user.is_valid_speaker():
+        return redirect('user_profile_update')
     logout_next = reverse('index')
     return render(request, 'users/user_dashboard.html', {
         'logout_next': logout_next,


### PR DESCRIPTION
修正了 #39 裡提到的一些東西。

最主要的部分：如果訪問 `user_dashboard` 的使用者尚未認證或 profile 不完整，我現在直接把他 redirect 到 `user_profile_update`。這樣註冊流程會順很多，也不用煩惱非 valid speaker 在 proposal 列表會空一塊的問題（因為看不到）。

其他修改：

1. Self-Introduction → Biography
2. Biography 欄位改成 `textarea`，裡面用 monospace font。
3. 其他很多用詞