### PR TITLE
在 Proposal Form 加入字元計數顯示

### DIFF
--- a/src/templates/proposals/_proposal_update.html
+++ b/src/templates/proposals/_proposal_update.html
@@ -26,6 +26,45 @@
 {% endif %}
 {% endblock main-content %}
 
+{% block scripts %}
+    {% trans "Character count: " as char_count %}
+    <script>
+        (function ($) {
+            // Copy from static/js/character-counter.js
+            var updateCharCount = function($counter, $source, initial){
+                var text = $source.val();
+                var length = text ? text.length : 0;
+                $counter.text(length);
+                var error = length >= parseFloat($source.attr("maxlength"));
+                // Only the first time updateCharCount being called has initial=true.
+                // If the limit is reached on load, don't trigger warning.
+                if (!initial) {
+                    // Make the field error
+                    $counter.closest('.form-group').toggleClass('has-warning', error);
+                    // Disable form submit button
+                    //$counter.closest('form').find('[type="submit"]')
+                    //        .prop('disabled', error);
+                }
+            };
+            // Inject counter to all textareas that have max char limit.
+            $('form textarea.textarea[maxlength]').each(function(){
+                var $source = $(this);
+                var $counterDisplay = $(
+                    "<p>{{ char_count }}"
+                    + "<span class=\"counter\"></span> / "
+                    + $(this).attr("maxlength")
+                    + "</span>"
+                ).addClass('help-block char-counter-display');
+                var $counter = $counterDisplay.find('span.counter');
+                $source.after($counterDisplay);
+                $source.on('input change', function () {
+                    updateCharCount($counter, $source, false);
+                });
+                updateCharCount($counter, $source, true);
+            });
+        })(jQuery);
+    </script>
+{% endblock %}
 
 {% block extra_js %}
 {{ block.super }}


### PR DESCRIPTION
見圖，在有字數限制的欄位下方，用 js 動態增加計數器。
<img width="369" alt="screen shot 2016-01-06 at 01 49 48" src="https://cloud.githubusercontent.com/assets/1544283/12122726/cba0a892-b417-11e5-9568-a6dcdfaa720a.png">

打滿的時候會變成 warning。
<img width="358" alt="screen shot 2016-01-06 at 01 51 12" src="https://cloud.githubusercontent.com/assets/1544283/12122770/11bbaf0c-b418-11e5-8767-f9fb22fd2294.png">
不過初始時就是滿的情況，就不會有 warning。

補充：我不會寫 Javascript / jQuery，麻煩教一下 m(_ _)m 