### PR TITLE
在 index.html, cfp.html 加入 og 資訊

### DIFF
--- a/src/templates/contents/en/speaking/cfp.html
+++ b/src/templates/contents/en/speaking/cfp.html
@@ -1,7 +1,15 @@
 {% extends 'contents/_base/speaking.html' %}
 
+{% load i18n static %}
+
 {% block title %}Call for Proposals{% endblock %}
 {% block page_title %}<h1>Call for Proposals</h1>{% endblock %}
+
+{% block meta_og %}
+  <meta property="og:title" content="Call for Proposals | PyCon Taiwan 2016" />
+  <meta property="og:description" content="The Call for Proposals (CfP) is now open. PyCon Taiwan 2016 is accepting talks and tutorial!" />
+  <meta property="og:image" content="http://{{ request.get_host }}{% static 'images/PyConTW2016_facebook_shareImage.png' %}" />
+{% endblock %}
 
 {% block content %}
     {% url 'page' path='speaking/recording' as speaking_recording_url %}
@@ -10,7 +18,7 @@
     {% url "signup" as signup_url %}
     {% url "user_dashboard" as dashboard_url %}
 
-    <p>The Call for Proposals (CfP) is now open. PyCon 2016 Taiwan is
+    <p>The Call for Proposals (CfP) is now open. PyCon Taiwan 2016 is
         accepting talks and tutorial!</p>
     <h2>Important Dates</h2>
     <ul>

--- a/src/templates/contents/zh/speaking/cfp.html
+++ b/src/templates/contents/zh/speaking/cfp.html
@@ -1,7 +1,15 @@
 {% extends 'contents/_base/speaking.html' %}
 
+{% load i18n static %}
+
 {% block title %}投稿募集{% endblock %}
 {% block page_title %}<h1>投稿募集（Call for Proposals）</h1>{% endblock %}
+
+{% block meta_og %}
+  <meta property="og:title" content="投稿募集（Call for Proposals）| PyCon Taiwan 2016" />
+  <meta property="og:description" content="即日起，PyCon Taiwan 2016 開始接受演講（Talk）與教學（Tutorial）的投稿！" />
+  <meta property="og:image" content="http://{{ request.get_host }}{% static 'images/PyConTW2016_facebook_shareImage.png' %}" />
+{% endblock %}
 
 {% block content %}
     {% url 'page' path='speaking/recording' as speaking_recording_url %}
@@ -11,7 +19,7 @@
     {% url "user_dashboard" as dashboard_url %}
 
     <p>
-        即日起，PyCon 2016 Taiwan 開始接受演講（Talk）與教學（Tutorial）的投稿！
+        即日起，PyCon Taiwan 2016 開始接受演講（Talk）與教學（Tutorial）的投稿！
     </p>
 
     <h2>重要日期</h2>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -2,6 +2,12 @@
 
 {% load i18n static %}
 
+{% block meta_og %}
+  <meta property="og:title" content="PyCon Taiwan 2016" />
+  <meta property="og:description" content="PyCon Taiwan is an annual convention in Taiwan for the discussion and promotion of the Python programming language. It is held by enthusiasts and focuses on Python technology and its versatile applications. We welcome people who are interested in Python to join PyCon Taiwan to share knowledge, exchange ideas, make connections and to help us grow our network." />
+  <meta property="og:image" content="http://{{ request.get_host }}{% static 'images/PyConTW2016_facebook_shareImage.png' %}" />
+{% endblock %}
+
 {% block titletag %}<title>PyCon Taiwan 2016</title>{% endblock titletag %}
 
 


### PR DESCRIPTION
(Issue #5)

在 `index.html`, `cfp.html` 加入 og 資訊
- [ ] `index.html` 的 og 文字需要翻譯

將 `cfp.html` 中的 “PyCon 2016 Taiwan” 改為 “PyCon Taiwan 2016”