### PR TITLE
Apply Noto Sans TC (via Google webfont)

### DIFF
--- a/src/static/css/_bootstrap-variables.scss
+++ b/src/static/css/_bootstrap-variables.scss
@@ -44,8 +44,7 @@ $text-color:            $gray !default;
 // //## Font, line-height, and color for body text, headings, and more.
 
 // $font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif !default;
-$font-family-sans-serif:  Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif !default;
-// $font-family-sans-serif:   Roboto, xingothic-tc,"Helvetica Neue", Helvetica, Arial, sans-serif !default;
+$font-family-sans-serif:  Roboto, "Noto Sans TC", "Helvetica Neue", Helvetica, Arial, "PingFangTC-regular", "Microsoft MHei", "Microsoft JhengHei", sans-serif !default;
 // $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 // //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 // $font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace !default;

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" type="text/x-scss" href="{% static 'css/main.scss' %}">
   {% endcompress %}
   <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500' rel='stylesheet' type='text/css'>
-  <link href='https://fonts.googleapis.com/earlyaccess/cwtexhei.css' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/earlyaccess/notosanstc.css' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   {% block extra_css %}{% endblock %}
   <!--[if lt IE 9]>


### PR DESCRIPTION
This supersedes #111 and fixes #98.

Safari on OS X:

![screen shot 2016-03-09 at 16 26 10](https://cloud.githubusercontent.com/assets/605277/13629918/2096f172-e617-11e5-8c80-7dbd1d4abcdf.png)


Edge on Windows 10:

![screen shot 2016-03-09 at 16 39 57](https://cloud.githubusercontent.com/assets/605277/13629901/13ae89fc-e617-11e5-9fc9-8f946ed9cf09.png)


Internet Explorer on Windows 10:

![screen shot 2016-03-09 at 16 45 54](https://cloud.githubusercontent.com/assets/605277/13629926/2a053ea8-e617-11e5-9891-ce7f22f67f5d.png)