### PR TITLE
修正 Markdown 欄位的 XSS 風險

### DIFF
--- a/src/core/widgets.py
+++ b/src/core/widgets.py
@@ -2,7 +2,6 @@ from django import forms
 from django.forms.utils import flatatt
 from django.utils.encoding import force_text
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 
 from .utils import split_css_class
 
@@ -37,7 +36,7 @@ class SimpleMDEWidget(forms.Textarea):
                 '<div class="editor-readonly">'
                 '<div class="editor-preview editor-preview-active">'
                 '{content}</div></div>',
-                content=mark_safe(value),
+                content=value,
             )
         else:
             attrs['data-simplemde'] = True

--- a/src/static/js/tools/simplemde-setup.js
+++ b/src/static/js/tools/simplemde-setup.js
@@ -23,15 +23,15 @@ for (var i = 0; i < elementList.length; i++) {
 if (!document.querySelectorAll || !window.DOMParser)
 	return;
 
+var parser = new DOMParser();
+
 var elementList = document.querySelectorAll(
 	'.editor-readonly > .editor-preview');
 for (var i = 0; i < elementList.length; i++) {
 	var element = elementList[i];
 	var source = element.textContent || element.innerText;
-
-	var doc = new DOMParser().parseFromString(source, 'text/html');
 	element.innerHTML = SimpleMDE.prototype.markdown(
-		doc.documentElement.textContent);
+		parser.parseFromString(source, 'text/html').documentElement.textContent);
 }
 
 })(SimpleMDE);

--- a/src/static/js/tools/simplemde-setup.js
+++ b/src/static/js/tools/simplemde-setup.js
@@ -2,17 +2,17 @@
 
 var elementList = document.getElementsByTagName('textarea');
 for (var i = 0; i < elementList.length; i++) {
-  var element = elementList[i];
-  if (!element.hasAttribute('data-simplemde')) {
-    continue;
-  }
-  new SimpleMDE({
-    'element': element,
-    'indentWithTabs': false,
-    'spellChecker': false,
-    'status': false,
-    'tabSize': 4
-  });
+	var element = elementList[i];
+	if (!element.hasAttribute('data-simplemde')) {
+		continue;
+	}
+	new SimpleMDE({
+		'element': element,
+		'indentWithTabs': false,
+		'spellChecker': false,
+		'status': false,
+		'tabSize': 4
+	});
 }
 
 })(SimpleMDE);
@@ -20,15 +20,18 @@ for (var i = 0; i < elementList.length; i++) {
 
 (function (SimpleMDE) {
 
-if (!document.querySelectorAll)
-       return;
+if (!document.querySelectorAll || !window.DOMParser)
+	return;
 
 var elementList = document.querySelectorAll(
-       '.editor-readonly > .editor-preview');
+	'.editor-readonly > .editor-preview');
 for (var i = 0; i < elementList.length; i++) {
-       var element = elementList[i];
-       element.innerHTML = SimpleMDE.prototype.markdown(
-               element.textContent || element.innerText);
+	var element = elementList[i];
+	var source = element.textContent || element.innerText;
+
+	var doc = new DOMParser().parseFromString(source, 'text/html');
+	element.innerHTML = SimpleMDE.prototype.markdown(
+		doc.documentElement.textContent);
 }
 
 })(SimpleMDE);


### PR DESCRIPTION
原本的實作使用 `mark_safe`，這代表如果 Markdown 欄位中有 raw HTML 會直接被執行，產生 XSS 風險。

新的實作改傳 escaped data，然後在 render 的時候用 `DOMParser` 把輸入值 unescape，然後再傳入 marked.js render 成 HTML，順便讓它負責剩下的 sanitation。

[`DOMParser` 只在 IE 10 以上支援](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#Browser_compatibility)，所以在較舊的瀏覽器上我就不 render 了，直接顯示 raw Markdown，應該也還可以接受。

處理 HTML unescaping 的參考資料：  
http://stackoverflow.com/questions/1912501#34064434