### PR TITLE
Fix length bug on querysets

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -67,11 +67,20 @@ class SequenceQuerySet:
     def __repr__(self):
         return '<SequenceQuerySet: {seq!r}>'.format(seq=self._seq)
 
-    def __getitem__(self, i):
-        return type(self)(self._seq[i])
+    def __len__(self):
+        return len(self._seq)
 
     def __iter__(self):
         return iter(self._seq)
+
+    def __bool__(self):
+        return bool(self._seq)
+
+    def __getitem__(self, i):
+        return type(self)(self._seq[i])
+
+    def all(self):
+        return self
 
     def count(self):
         return len(self._seq)

--- a/src/templates/reviews/talk_proposal_list.html
+++ b/src/templates/reviews/talk_proposal_list.html
@@ -55,7 +55,7 @@
 <!-- Nav tabs -->
 <ul class="nav nav-tabs reviews-tabs" role="tablist">
     <li role="presentation" class="active"><a href="#unreviewed" aria-controls="unreviewed" role="tab" data-toggle="tab">{% trans 'Unreviewed Talk Proposals' %} ({{ object_list|length }})</a></li>
-    <li role="presentation"><a href="#reviewed" aria-controls="reviewed" role="tab" data-toggle="tab">{% trans 'Reviewed Talk Proposals' %} ({{ reviews.count }})</a></li>
+    <li role="presentation"><a href="#reviewed" aria-controls="reviewed" role="tab" data-toggle="tab">{% trans 'Reviewed Talk Proposals' %} ({{ reviews|length }})</a></li>
 </ul>
 <!-- Tab panes -->
 <div class="tab-content">

--- a/src/templates/reviews/talk_proposal_list.html
+++ b/src/templates/reviews/talk_proposal_list.html
@@ -54,7 +54,7 @@
 </div>
 <!-- Nav tabs -->
 <ul class="nav nav-tabs reviews-tabs" role="tablist">
-    <li role="presentation" class="active"><a href="#unreviewed" aria-controls="unreviewed" role="tab" data-toggle="tab">{% trans 'Unreviewed Talk Proposals' %} ({{ object_list.count }})</a></li>
+    <li role="presentation" class="active"><a href="#unreviewed" aria-controls="unreviewed" role="tab" data-toggle="tab">{% trans 'Unreviewed Talk Proposals' %} ({{ object_list|length }})</a></li>
     <li role="presentation"><a href="#reviewed" aria-controls="reviewed" role="tab" data-toggle="tab">{% trans 'Reviewed Talk Proposals' %} ({{ reviews.count }})</a></li>
 </ul>
 <!-- Tab panes -->

--- a/src/templates/reviews/talk_proposal_list.html
+++ b/src/templates/reviews/talk_proposal_list.html
@@ -55,7 +55,7 @@
 <!-- Nav tabs -->
 <ul class="nav nav-tabs reviews-tabs" role="tablist">
     <li role="presentation" class="active"><a href="#unreviewed" aria-controls="unreviewed" role="tab" data-toggle="tab">{% trans 'Unreviewed Talk Proposals' %} ({{ object_list.count }})</a></li>
-    <li role="presentation"><a href="#reviewed" aria-controls="reviewed" role="tab" data-toggle="tab">{% trans 'Reviewed Talk Proposals' %} ({{ reviews|length }})</a></li>
+    <li role="presentation"><a href="#reviewed" aria-controls="reviewed" role="tab" data-toggle="tab">{% trans 'Reviewed Talk Proposals' %} ({{ reviews.count }})</a></li>
 </ul>
 <!-- Tab panes -->
 <div class="tab-content">


### PR DESCRIPTION
Add missing magic methods for API compatibility.
We should use .count anyway.