### PR TITLE
Refactor cancel filter into filter_reviewable

### DIFF
--- a/src/proposals/models.py
+++ b/src/proposals/models.py
@@ -107,6 +107,7 @@ class ProposalQuerySet(models.QuerySet):
 
     def filter_reviewable(self, user):
         return self.exclude(
+            Q(cancelled=True) |
             Q(submitter=user) |
             Q(additionalspeaker_set__in=user.cospeaking_info_set.all())
         )

--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -42,7 +42,6 @@ class TalkProposalListView(PermissionRequiredMixin, ListView):
         user = self.request.user
         proposals = (
             self.model.objects
-            .filter(cancelled=False)
             .filter_reviewable(user)
             .exclude(review__stage=ReviewsConfig.stage, review__reviewer=user)
             .annotate(review_count=Count('review'))
@@ -103,7 +102,6 @@ class ReviewEditView(PermissionRequiredMixin, UpdateView):
         try:
             proposal = (
                 self.proposal_model.objects
-                .filter(cancelled=False)
                 .filter_reviewable(self.request.user)
                 .get(pk=self.kwargs['proposal_pk'])
             )


### PR DESCRIPTION
原本有個小問題是 `ReviewForm` 可以 review 已取消的 proposal（雖然因為沒有連結，大概也很難找到 proposal 網址來 review）。