### PR TITLE
Carry query string from list view to form

### DIFF
--- a/src/reviews/views.py
+++ b/src/reviews/views.py
@@ -82,6 +82,7 @@ class TalkProposalListView(PermissionRequiredMixin, ListView):
                 vote=Review.Vote.MINUS_ONE).count(),
         }
         context['ordering'] = self.ordering
+        context['query_string'] = self.request.GET.urlencode()
         return context
 
     def get_reviews(self):
@@ -144,4 +145,8 @@ class ReviewEditView(PermissionRequiredMixin, UpdateView):
         return data
 
     def get_success_url(self):
-        return reverse('review_proposal_list')
+        query_string = self.request.GET.urlencode()
+        url = reverse('review_proposal_list')
+        if query_string:
+            return url + '?' + query_string
+        return url

--- a/src/templates/reviews/_includes/proposal_table.html
+++ b/src/templates/reviews/_includes/proposal_table.html
@@ -54,7 +54,7 @@
             <td class="hidden-md hidden-sm hidden-xs">{{ proposal.get_python_level_display }}</td>
             <td class="hidden-md hidden-sm hidden-xs">{{ proposal.get_language_display }}</td>
             <td>
-                <a href="{% url 'review_edit' proposal_pk=proposal.pk %}" class="btn btn-natural">{% trans 'Review' %}</a>
+                <a href="{% url 'review_edit' proposal_pk=proposal.pk %}{% if query_string %}?{{ query_string }}{% endif %}" class="btn btn-natural">{% trans 'Review' %}</a>
             </td>
         </tr>
         {% endfor %}

--- a/src/templates/reviews/_includes/review_table.html
+++ b/src/templates/reviews/_includes/review_table.html
@@ -16,7 +16,7 @@
             <td class="proposal-title">{{ review.proposal.title }}</td>
             <td class="hidden-xs">{{ review.comment|truncatechars:20 }}</td>
             <td>
-                <a href="{% url 'review_edit' proposal_pk=review.proposal.pk %}" class="btn btn-natural btn-reactivate">{% trans 'Update' %}</a>
+                <a href="{% url 'review_edit' proposal_pk=review.proposal.pk %}{% if query_string %}?{{ query_string }}{% endif %}" class="btn btn-natural btn-reactivate">{% trans 'Update' %}</a>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
The list view now carries the query string when going to the review
form view. The latter can then uses it when redirecting back to the
list view.

Fix #158.