### PR TITLE
Cleanup and reword ticket info pages

### DIFF
--- a/src/static/css/components/_tables.scss
+++ b/src/static/css/components/_tables.scss
@@ -7,31 +7,25 @@
 .table-pycon {
     @include roboto-light;
 
-    tr:first-child{
+    > thead > tr {
         background: $theme-color;
         border-radius:3px 3px 0 0;
         height:60px;
     }
-
-    th{
+    th, td {
         @include table_text_style();
+    }
+    th {
         font-size:16px;
         color:#ffffff;
     }
-
-    td{
-        @include table_text_style();
+    td {
         font-size: 14px;
     }
-
     .table-pycon__description {
         @include roboto-light;
         font-weight: 300;
         width: 250px;
         text-align: left;
     }
-
 }
-
-
-

--- a/src/templates/contents/en/registration/ticket-info.html
+++ b/src/templates/contents/en/registration/ticket-info.html
@@ -17,6 +17,7 @@
 	</div>
 		<div class="pycon-list-item text-theme-highlight">
 		Early bird tickets are limited; sale ends at <span class="text-emphasize text-theme-highlight">May 1 18:04 CST</span>.
+        Early bird student tickets are sold out. Fifty extra student tickets will be released at the same time.
 	</div>
 		<div class="pycon-list-item text-theme-highlight">
 		Sale of all tickets ends at <span class="text-emphasize text-theme-highlight">May 13 18:05 CST</span>.
@@ -109,7 +110,7 @@
 <ul>
 	<li>All price settled in New Taiwan Dollars (NTD); NTD 32.41 = USD 1.00 (Apr. 14, 2016).</li>
 	<li>Company Unified Business Number will be present on receipts for those who require reimbursement.</li>
-	<li>If you require English receipts, or have any questions regarding ticket sales, please email to <em>registration[at]pycon.tw</em>.</li>
+	<li>If you require English receipts, or have any questions regarding ticket sales, please email to <em>organizers[at]pycon.tw</em>.</li>
 </ul>
 
 <h2>Notices</h2>
@@ -183,7 +184,7 @@
 <p>Please provide valid means of contact (phone number and email) on purchase, so that we will be able to inform you of any important notices.</p>
 
 <h4>8. Ticketing Consultancy</h4>
-<p>Please kindly email to <em>registration[at]pycon.tw</em> if you have any questions regarding ticket information. We will reply you as soon as possible!
+<p>Please kindly email to <em>organizers[at]pycon.tw</em> if you have any questions regarding ticket information. We will reply you as soon as possible!
 </p>
 
 <h4>9. Tutorials and PyDay</h4>

--- a/src/templates/contents/en/registration/ticket-info.html
+++ b/src/templates/contents/en/registration/ticket-info.html
@@ -6,348 +6,191 @@
 
 {% block content %}
 
-    {% url 'page' path='events/pyday' as events_pyday_url %}
-    {% url 'page' path='registration/financial-aid' as reg_financial_aid_url%}
+{% url 'page' path='events/pyday' as events_pyday_url %}
+{% url 'page' path='events/sprints' as events_sprints_url %}
+{% url 'page' path='registration/financial-aid' as reg_financial_aid_url%}
 
+<div class="pycon-list">
+	<div class="pycon-list-item text-theme-highlight">
+		Ticket sale begins at
+		<span class="text-emphasize">April 18 18:03 CST</span>.
+	</div>
+		<div class="pycon-list-item text-theme-highlight">
+		Early bird tickets are limited; sale ends at <span class="text-emphasize text-theme-highlight">May 1 18:04 CST</span>.
+	</div>
+		<div class="pycon-list-item text-theme-highlight">
+		Sale of all tickets ends at <span class="text-emphasize text-theme-highlight">May 13 18:05 CST</span>.
+	</div>
+</div>
 
-    <div class="pycon-list">
-        <div class="pycon-list-item text-theme-highlight">
-            Ticket sale begins on
-            <span class="text-emphasize ">
-                April 18 18:03.
-            </span>
-        </div>
-            <div class="pycon-list-item text-theme-highlight">
-            Early bird tickets are limited and the sales will end on
-            <span class="text-emphasize text-theme-highlight">
-                May 1 18:04.
-            </span>
-        </div>
-            <div class="pycon-list-item text-theme-highlight">
-            Sale of other tickets ends on
-            <span class="text-emphasize text-theme-highlight">
-                May 13 18:05.
-            </span>
-        </div>
-    </div>
+<h2>Ticket Info</h2>
 
+<p>The following tickets provide access to the main conference during June 3 and 5. Please refer to their own pages for tutorial and sprint registrations.</p>
 
-    <h2>
-        Ticket Info
-    </h2>
-    <p>
-        Please read the follow description in below table
-    </p>
+<div class="table-responsive">
+	<table class="table table-pycon">
+		<thead>
+			<tr>
+				<th></th>
+				<th>Early bird rate</th>
+				<th>Regular rate</th>
+				<th>Link</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<td class="text-emphasize">Regular</td>
+			<td class="text-emphasize text-theme-highlight">4,490</td>
+			<td>4,990</td>
+			<td>
+				<a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-regular" target="_blank">
+					Buy
+				</a>
+			</td>
+			<td class="table-pycon__description">
+				<p>
+					You will receive an <a href="https://drive.google.com/file/d/0B3KccB4PeNEOcmk5WktscGJpRG8/view">electronic receipt</a> for this ticket when you check in at PyCon.
+				</p>
+				<p>
+					Please provide your company’s name and Unified Business Number, or <em>N/A</em> if reimbursement is not required.
+				</p>
+			</td>
+		</tr>
 
-    <div class="table-responsive">
+		<tr>
+			<td class="text-emphasize">Discount</td>
+			<td class="text-theme-highlight text-emphasize">2,190</td>
+			<td>2,690</td>
+			<td>
+				<a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-ocf" target="_blank">
+					Buy
+				</a>
+			</td>
+			<td class="table-pycon__description">
+				Your invoice will be donated directly to the <a href="http://ocf.tw/">Open Culture Foundation</a>. A discount is thus offered to appreciate you donation.
+			</td>
+		</tr>
 
-        <table class="table table-pycon">
-            <tbody>
+		<tr>
+			<td class="text-emphasize">Students</td>
+			<td class="text-emphasize text-theme-highlight">1,390</td>
+			<td>1,790</td>
+			<td>
+				<a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-student" target="_blank">
+					Buy
+				</a>
+			</td>
+			<td class="table-pycon__description">
+				<p>Your invoice will be donated directly to the <a href="http://ocf.tw/">Open Culture Foundation</a>. A discount is thus offered to appreciate you donation.</p>
 
-            <tr>
-                <th> </th>
-                <th>
-                    Early bird rate
-                </th>
-                <th>
-                    Regular rate
-                </th>
-                <th>
-                    Link
-                </th>
-                <th>
-                    Description
-                </th>
-            </tr>
+				<p>This discount is for students only. You are required to provide identification of eligibility (student ID card) when checking in at the conference.</p>
+			</td>
+		</tr>
 
-            <tr>
-                <td class="text-emphasize">
-                    Discount
-                </td>
-                <td class="text-theme-highlight text-emphasize">
-                    2,190
-                </td>
-                <td>
-                    2,690
-                </td>
-                <td>
-                    <a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-ocf" target="_blank">
-                        Buy
-                    </a>
-                </td>
-                <td class="table-pycon__description">
-                    Appreciating you donation, we will give you price discount. The invoice will directly donate to
-                    <a href="http://ocf.tw/">
-                        Open Culture Foundation
-                    </a>
-                </td>
-            </tr>
+		<tr>
+			<td class="text-emphasize">Speakers</td>
+			<td class="text-emphasize text-theme-highlight" colspan="2">2,190</td>
+			<td>
+				<a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-speaker" target="_blank">
+					Buy
+				</a>
 
-            <tr>
-                <td class="text-emphasize">
-                    Student
-                </td>
-                <td class="text-emphasize text-theme-highlight">
-                    1,390
-                </td>
-                <td>1,790</td>
-                <td>
-                    <a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-student" target="_blank">
-                        Buy
-                    </a>
-                </td>
-                <td class="table-pycon__description">
-                    Appreciating your donation, we will give you price discount. The invoice will directly donate to
-                    <a href="http://ocf.tw/">
-                        Open Culture Foundation
-                    </a>
-                    <br/>
+			</td>
+			<td class="table-pycon__description">
+				For speakers. Please enter your invitation code when purchasing the ticket.
+			</td>
+		</tr>
+		</tbody>
+	</table>
 
-                    Discount for on-campus student only. Proof of eligibility (student ID card) required at check-in
-                </td>
-            </tr>
+</div>
 
-            <tr>
-                <td class="text-emphasize">
-                    Speaker
-                </td>
-                <td class="text-emphasize text-theme-highlight" colspan=2>     2,190</td>
-                <td>
-                    <a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-speaker" target="_blank">
-                        Buy
-                    </a>
+<ul>
+	<li>All price settled in New Taiwan Dollars (NTD); NTD 32.41 = USD 1.00 (Apr. 14, 2016).</li>
+	<li>Company Unified Business Number will be present on receipts for those who require reimbursement.</li>
+	<li>If you require English receipts, or have any questions regarding ticket sales, please email to <em>registration[at]pycon.tw</em>.</li>
+</ul>
 
-                </td>
-                <td class="table-pycon__description">
-                    For speakers. Please enter the invitation code when buying the ticket.
-                </td>
-            </tr>
+<h2>Notices</h2>
+<h4>1. T-shirt Size</h4>
 
-            <tr>
+<p>Every registered participant will receive a souvenir T-shirt. Please check your size according to the following table.</p>
 
-                <td class="text-emphasize">
-                    Regular
-                </td>
-                <td class="text-emphasize text-theme-highlight">
-                    4,490
-                </td>
-                <td>
-                    4,990
-                </td>
-                <td>
-                    <a class="btn btn-action text-emphasize" href="http://pycontw.kktix.cc/events/pycontw2016-regular" target="_blank">
-                        Buy
-                    </a>
-                </td>
-                <td class="table-pycon__description">
-                    <p>
-                        You’ll get the <a href="https://drive.google.com/file/d/0B3KccB4PeNEOcmk5WktscGJpRG8/view">electronic receipt</a> for this ticket
-                        when you check in during PyCon .
-                    </p>
-                    <p>
-                        Please provide your company name and
-                        Unified Business No..
-                    </p>
-                    <p>
-                        For those who don’t reimburse, please fill
-                        “N/A” in these two column.
-                    </p>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+<div class="table-responsive">
+	<table class="table table-pycon">
+		<thead>
+			<tr>
+				<th class="text-emphasize">Size</th>
+				<th>XS</th>
+				<th>S</th>
+				<th>M</th>
+				<th>L</th>
+				<th>XL</th>
+				<th>2XL</th>
+				<th>3XL</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td class="text-emphasize">Height (cm)</td>
+				<td>Under 150</td>
+				<td>150–160</td>
+				<td>160–170</td>
+				<td>170–180</td>
+				<td colspan="3">Above 180</td>
+			</tr>
+			<tr>
+				<td class="text-emphasize">Chest Width</td>
+				<td>44.5</td>
+				<td>47</td>
+				<td>49.5</td>
+				<td>52</td>
+				<td>54.5</td>
+				<td>57</td>
+				<td>59.5</td>
+			</tr>
+			<tr>
+				<td class="text-emphasize">Back Length from HPS</td>
+				<td>62</td>
+				<td>63.5</td>
+				<td>66</td>
+				<td>68.5</td>
+				<td>71</td>
+				<td>73.5</td>
+				<td>73.5</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
 
-    </div>
+<h4>2. Everybody Pays</h4>
+<p>PyCon Taiwan 2016 is a paid conference. Everybody, including staffs and speakers, pays for attending (see <a href="http://jessenoller.com/blog/2011/05/25/pycon-everybody-pays" target="_blank">PyCon: Everybody Pays</a>).</p>
 
+<h4>3. Ways To Pay for Tickets</h4>
+<p>You can pay through credit card, PayPal, or ATM transfer.</p>
 
+<h4>4. No Refund</h4>
+<p>There will be no refund once registration is confirmed.</p>
 
-    <ul>
-        <li>The price is settled in New Taiwan Dollar(NTD); NTD 32.41 = USD 1.00 (Apr. 14)
-        <li>There will be Unified Business No. on the receipt for those who need to reimburse.
-        <li>If you need English receipt, please mail to registration[at]pycon.tw
+<h4>5. Financial Aid Plan</h4>
+<p>You can contact us for a financial aid if you feel any difficulty affording a ticket and/or other expanses attending the conference. You will need to purchase the ticket before applying. More info about applications can be found <a href="{{ reg_financial_aid_url }}">here</a>.</p>
 
-    </ul>
+<h4>6. Dietary Requirements</h4>
+<p>We provide lunch during the conference. Please let us know if you have any specific dietary requirements.</p>
 
-    <h2>Notice</h2>
-    <h4>1. The Size of T-shirt
+<h4>7. Contact Information Accuracy</h4>
+<p>Please provide valid means of contact (phone number and email) on purchase, so that we will be able to inform you of any important notices.</p>
 
-    </h4>
+<h4>8. Ticketing Consultancy</h4>
+<p>Please kindly email to <em>registration[at]pycon.tw</em> if you have any questions regarding ticket information. We will reply you as soon as possible!
+</p>
 
-    <p>
-        Every registered participant will get a souvenir T-shirt. Please check your size by the following table.
-    </p>
+<h4>9. Tutorials and PyDay</h4>
+<p>You will be able to verify information about tutorials (annoucement pending), <a href="{{ events_sprints_url }}">sprints</a>, and <a href="{{ events_pyday_url }}">PyDay</a>.</p>
 
-    <div class="table-responsive">
+<hr>
 
-        <table class="table table-pycon">
-            <tbody>
-            <tr>
-                <th class='text-emphasize' colspan="1" rowspan="1">
-                    Size
-                </th>
-                <th colspan="1" rowspan="1">
-                    XS
-                </th>
-                <th colspan="1" rowspan="1">
-                    S
-                </th>
-                <th colspan="1" rowspan="1">
-                    M
-                </th>
-                <th colspan="1" rowspan="1">
-                    L
-                </th>
-                <th colspan="1" rowspan="1">
-                    XL
-                </th>
-                <th colspan="1" rowspan="1">
-                    2XL
-                </th>
-                <th colspan="1" rowspan="1">
-                    3XL
-                </th>
-            </tr>
-            <tr>
-                <td class='text-emphasize' colspan="1" rowspan="1">
-
-                    Height(cm)
-
-                </td>
-                <td colspan="1" rowspan="1">
-                    under 150
-                </td>
-                <td colspan="1" rowspan="1">
-                    150~160
-                </td>
-                <td colspan="1" rowspan="1">
-                    160~170
-                </td>
-                <td colspan="1" rowspan="1">
-                    170~180
-                </td>
-                <td colspan="3" rowspan="1">
-                    above 180
-
-                </td>
-            </tr>
-            <tr>
-                <td class='text-emphasize' colspan="1" rowspan="1">
-                    Chest Width
-                </td>
-                <td colspan="1" rowspan="1">
-                    44.5
-                </td>
-                <td colspan="1" rowspan="1">
-                    47
-                </td>
-                <td colspan="1" rowspan="1">
-                    49.5
-                </td>
-                <td colspan="1" rowspan="1">
-                    52
-                </td>
-                <td colspan="1" rowspan="1">
-                    54.5
-                </td>
-                <td colspan="1" rowspan="1">
-                    57
-                </td>
-                <td colspan="1" rowspan="1">
-                    59.5
-                </td>
-            </tr>
-            <tr>
-                <td class='text-emphasize' colspan="1" rowspan="1">
-                    Back Length from HPS
-                </td>
-                <td colspan="1" rowspan="1">
-                    62
-                </td>
-                <td colspan="1" rowspan="1">
-                    63.5
-                </td>
-                <td colspan="1" rowspan="1">
-                    66
-                </td>
-                <td colspan="1" rowspan="1">
-                    68.5
-                </td>
-                <td colspan="1" rowspan="1">
-                    71
-                </td>
-                <td colspan="1" rowspan="1">
-                    73.5
-                </td>
-                <td colspan="1" rowspan="1">
-                    73.5
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
-
-    <h4>2. Everybody Pays</h4>
-    <p>
-        PyCon Taiwan 2016 is a paid conference; Everybody, including staffs and speakers, has to pay for attending ( see
-        <a href="http://jessenoller.com/blog/2011/05/25/pycon-everybody-pays">
-            PyCon:Everybody Pays
-        </a>
-        ）
-    </p>
-
-
-    <h4>3. Ways To Pay for Tickets</h4>
-    <p>
-        You can pay through credit cards, PayPal, and ATM transfer..
-    </p>
-
-
-    <h4>4. No Refund</h4>
-    <p>
-        There would be no refund once registration is confirmed.
-    </p>
-
-
-    <h4>5. Financial Aid Plan </h4>
-
-    <p>
-        If you are struggling with finances and can't afford a ticket, please contact us for Financial Aid, but you need to purchase the ticket before applying for financial aid.
-        More info about applications can be found
-
-        <a href="{{ reg_financial_aid_url }}">
-            here
-        </a>。
-    </p>
-
-
-    <h4>
-        6. Special Food Taboos
-    </h4>
-    <p>
-        We will provide lunch during conference. Let us know if you are a vegetarian or non-pork eaters.
-    </p>
-
-
-    <h4>
-        7. Please leave the correct Information
-    </h4>
-
-    <h4>
-        8. Ticketing Consultancy
-    </h4>
-    <p>
-        Please kindly mail to registration[at]pycon.tw If you have any question about ticketing. We will reply you ASAP!
-    </p>
-
-    <h4>
-        9. About Tutorial and PyDay
-    </h4>
-
-    <p>Please refer to Tutorial and <a href="{{ events_pyday_url }}">PyDay</a> </p>
-
-    <p>
-        We are looking forward that every Pythonista could attend our PyCon Taiwan 2016!
-    </p>
-
+<p>We look forward to your participation at PyCon Taiwan 2016!</p>
 
 {% endblock %}

--- a/src/templates/contents/zh/registration/ticket-info.html
+++ b/src/templates/contents/zh/registration/ticket-info.html
@@ -21,7 +21,7 @@
 		<span class="text-emphasize text-theme-highlight">
 		   2016 年 5 月 1 日 18:04
 		</span>
-		早鳥票截止，各票種恢復原價販售，預計為期兩週。
+        早鳥票截止，各票種恢復原價販售，預計為期兩週。學生票已全數售罄，為因應學生踴躍購票，將於同時間販售額外50張原價學生票
 	</div>
 		<div class="pycon-list-item text-theme-highlight">
 		<span class="text-emphasize text-theme-highlight">
@@ -116,7 +116,7 @@
 	<li>若無特別標註，皆以台幣計價；請參考 2016-04-14 匯率 USD 1.00 = NTD 32.41。</li>
 	<li><a href="http://itn.tw/knowledgebase.php?action=displayarticle&id=68">電子發票標示買方統編</a>，可用於公司報帳；個人留存之用的電子發票，只會顯示賣方統編。</li>
 	<li>各級學校就讀的學生，包括研究所、大專院校、中小學生等，可購買學生票。</li>
-	<li>如需開立英文收據，或票務相關問題，請來信 registration[at]pycon.tw 洽詢。</li>
+	<li>如需開立英文收據，或票務相關問題，請來信 organizers[at]pycon.tw 洽詢。</li>
 </ul>
 
 <h2>注意事項</h2>
@@ -184,7 +184,7 @@
 
 
 <h4>4. 不接受退票</h4>
-<p>本次活動恕不受理退票。僅受理補差額更改優惠票成一般票，須於售票截止前 (2016 年 5 月 13 日) 寄信至 registration[at]pycon.tw 告知，活動方將於更改完成後，寄信通知買方。</p>
+<p>本次活動恕不受理退票。僅受理補差額更改優惠票成一般票，須於售票截止前 (2016 年 5 月 13 日) 寄信至 organizers[at]pycon.tw 告知，活動方將於更改完成後，寄信通知買方。</p>
 
 
 <h4>5. 財務補助計畫（Financial Aid Plan）</h4>
@@ -201,7 +201,7 @@
 
 
 <h4>8. 票務諮詢管道</h4>
-<p>如有任何問題，請寄信至 registration[at]pycon.tw 洽詢，我們將盡快給予回應。</p>
+<p>如有任何問題，請寄信至 organizers[at]pycon.tw 洽詢，我們將盡快給予回應。</p>
 
 <h4>9. 關於 PyCon 課程 (Tutorial)、PyDay</h4>
 

--- a/src/templates/contents/zh/registration/ticket-info.html
+++ b/src/templates/contents/zh/registration/ticket-info.html
@@ -1,319 +1,216 @@
 {% extends 'contents/_base/registration.html' %}
 
 {% block title %}售票資訊{% endblock title %}
-{% block page_title %}<h1>售票資訊 (Conference Ticket)</h1>{% endblock page_title %}
+{% block page_title %}<h1>售票資訊 (Conference Tickets)</h1>{% endblock page_title %}
 
 
 {% block content %}
 
-    {% url 'page' path='events/pyday' as events_pyday_url %}
-    {% url 'page' path='events/sprints' as events_sprints_url %}
-    {% url 'page' path='registration/financial-aid' as reg_financial_aid_url%}
+{% url 'page' path='events/pyday' as events_pyday_url %}
+{% url 'page' path='events/sprints' as events_sprints_url %}
+{% url 'page' path='registration/financial-aid' as reg_financial_aid_url%}
 
-    <div class="pycon-list">
-        <div class="pycon-list-item text-theme-highlight">
-            <span class="text-emphasize ">
-            2016 年 4 月 18 日 18：03
-            </span>
-            開始售票；各票種早鳥優惠為期兩週。
-        </div>
-            <div class="pycon-list-item text-theme-highlight">
-            <span class="text-emphasize text-theme-highlight">
-               2016 年 5 月 1 日 18：04
-            </span>
-            早鳥票截止，各票種恢復原價販售，預計為期兩週。
-        </div>
-            <div class="pycon-list-item text-theme-highlight">
-            <span class="text-emphasize text-theme-highlight">
-               2016 年 5 月 13 日 18：05
-            </span>
-            預計截止售票。
-        </div>
-    </div>
+<div class="pycon-list">
+	<div class="pycon-list-item text-theme-highlight">
+		<span class="text-emphasize">
+		2016 年 4 月 18 日 18:03
+		</span>
+		開始售票；各票種早鳥優惠為期兩週。
+	</div>
+		<div class="pycon-list-item text-theme-highlight">
+		<span class="text-emphasize text-theme-highlight">
+		   2016 年 5 月 1 日 18:04
+		</span>
+		早鳥票截止，各票種恢復原價販售，預計為期兩週。
+	</div>
+		<div class="pycon-list-item text-theme-highlight">
+		<span class="text-emphasize text-theme-highlight">
+		   2016 年 5 月 13 日 18:05
+		</span>
+		預計截止售票。
+	</div>
+</div>
 
-    <h2>
-        票種說明
-    </h2>
-    <p>
-        下列票種用於報名六月3日至5日的議程活動；
-        Tutorials 及 Sprints 的報名方式，請另見相關網頁說明。
-    </p>
+<h2>
+	票種說明
+</h2>
+<p>
+	下列票種用於報名 6 月 3 日至 5 日的議程活動；tutorials 及 sprints 的報名方式，請另見相關網頁說明。
+</p>
 
-    <div class="table-responsive">
+<div class="table-responsive">
+	<table class="table table-pycon">
+	<thead>
+		<tr>
+			<th></th>
+			<th>早鳥票價</th>
+			<th>原票價</th>
+			<th>購票網址</th>
+			<th>說明</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="text-emphasize">一般票</td>
+			<td class="text-theme-highlight text-emphasize">4,490</td>
+			<td>4,990</td>
+			<td>
+				<a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-regular" target="_blank">
+					按此購票
+				</a>
+			</td>
+			<td class="table-pycon__description">
+				有統編需求，請填寫公司抬頭與統一編號。無統編需求，請於抬頭與統編填寫 <em>N/A</em>。電子發票於報到櫃台交付。
+			</td>
+		</tr>
+		<tr>
+			<td class="text-emphasize">優惠票</td>
+			<td class="text-theme-highlight text-emphasize">2,190</td>
+			<td>2,690</td>
+			<td>
+				<a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-ocf" target="_blank">
+					按此購票
+				</a>
+			</td>
+			<td class="table-pycon__description">
+				發票將捐贈給<a href="http://ocf.tw/">開放文化基金會</a>，對此大會予以票價優惠。
+			</td>
+		</tr>
 
-        <table class="table table-pycon">
-            <tbody>
+		<tr>
+			<td class="text-emphasize">學生票</td>
+			<td class="text-theme-highlight text-emphasize">1,390</td>
+			<td>1,790</td>
+			<td>
+				<a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-student" target="_blank">
+					按此購票
+				</a>
+			</td>
+			<td class="table-pycon__description">
+				<p>發票將捐贈給<a href="http://ocf.tw/">開放文化基金會</a>，對此大會予以票價優惠。</p>
+				<p>報到需出示學生證，無法出示證明者，大會有權保留進場資格。</p>
+			</td>
+		</tr>
 
-            <tr>
-                <th> </th>
-                <th>
-                    早鳥票價
-                </th>
-                <th>
-                    原票價
-                </th>
-                <th>
-                    購票網址
-                </th>
-                <th>
-                    說明
-                </th>
-            </tr>
+		<tr>
+			<td class="text-emphasize">講者票</td>
+			<td class="text-emphasize text-theme-highlight" colspan="2">2,190</td>
+			<td>
+				<a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-speaker" target="_blank">
+					按此購票
+				</a>
 
-            <tr>
-                <td class="text-emphasize">
-                    一般票
-                </td>
-                <td class="text-theme-highlight text-emphasize">4,490</td>
-                <td>4,990</td>
-                <td>
-                    <a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-regular" target="_blank">
-                        按此購票
-                    </a>
-                </td>
-                <td class="table-pycon__description">
-                    有統編需求，請填寫公司抬頭與統一編號。
-                    無統編需求，請於抬頭與統編填寫 N/A。
-                    電子發票於報到櫃台交付。
-                </td>
-            </tr>
+			</td>
+			<td class="table-pycon__description">
+				講者專用，報名時請輸入邀請碼。
+			</td>
+		</tr>
+		</tbody>
+	</table>
 
-            <tr>
-                <td class="text-emphasize">
-                    優惠票
-                </td>
-                <td class="text-theme-highlight text-emphasize">
-                    2,190
-                </td>
-                <td>
-                    2,690
-                </td>
-                <td>
-                    <a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-ocf" target="_blank">
-                        按此購票
-                    </a>
-                </td>
-                <td class="table-pycon__description">
-                    發票將捐贈給
-                    <a href="http://ocf.tw/">
-                        開放文化基金會
-                    </a>
-                    ， 對此大會予以票價優惠。
-                </td>
-            </tr>
-
-            <tr>
-                <td class="text-emphasize">
-                    學生票
-                </td>
-                <td class="text-theme-highlight text-emphasize">1,390</td>
-                <td>1,790</td>
-                <td>
-                    <a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-student" target="_blank">
-                        按此購票
-                    </a>
-                </td>
-                <td class="table-pycon__description">
-                    發票將捐贈給
-                    <a href="http://ocf.tw/">
-                        開放文化基金會
-                    </a>
-                    ，對此大會予以票價優惠。<br/>
-                    報到需出示學生證，無法出示證明者，大會有權保留進場資格。
-                </td>
-            </tr>
-
-            <tr>
-                <td class="text-emphasize">
-                    講者票
-                </td>
-                <td class='text-emphasize text-theme-highlight'colspan=2>
-                    2,190
-                </td>
-                <td>
-                    <a class="btn btn-action" href="http://pycontw.kktix.cc/events/pycontw2016-speaker" target="_blank">
-                        按此購票
-                    </a>
-
-                </td>
-                <td class="table-pycon__description">
-                    講者專用，報名時請輸入邀請碼。
-                </td>
-            </tr>
-            </tbody>
-        </table>
-
-    </div>
+</div>
 
 
 
-    <ul>
-        <li><a href="http://itn.tw/knowledgebase.php?action=displayarticle&id=68">電子發票標示買方統編</a>，可用於公司報帳；個人留存之用的電子發票，只會顯示賣方統編。</li>
-        <li>各級學校就讀的學生，包括研究所、大專院校、中小學生等，可購買學生票。</li>
-        <li>若無特別標註，皆以台幣計價；請參考 2016.04.14 匯率 USD 1.00 = NTD 32.41。</li>
-        <li>如需開立英文收據，或票務相關問題，請來信 registration[at]pycon.tw 洽詢。</li>
-    </ul>
+<ul>
+	<li>若無特別標註，皆以台幣計價；請參考 2016-04-14 匯率 USD 1.00 = NTD 32.41。</li>
+	<li><a href="http://itn.tw/knowledgebase.php?action=displayarticle&id=68">電子發票標示買方統編</a>，可用於公司報帳；個人留存之用的電子發票，只會顯示賣方統編。</li>
+	<li>各級學校就讀的學生，包括研究所、大專院校、中小學生等，可購買學生票。</li>
+	<li>如需開立英文收據，或票務相關問題，請來信 registration[at]pycon.tw 洽詢。</li>
+</ul>
 
-    <h2>注意事項</h2>
-    <h4> 1. T 裇尺寸 </h4>
+<h2>注意事項</h2>
+<h4> 1. T 裇尺寸 </h4>
 
-    <p>
-        每一位報名參加者皆能獲得紀念 T 裇一件，請在報名時填寫您的尺寸。尺寸請參考下表：
-    </p>
+<p>
+	每一位報名參加者皆能獲得紀念 T 裇一件，請在報名時填寫您的尺寸。尺寸請參考下表：
+</p>
 
-    <div class="table-responsive">
+<div class="table-responsive">
+	<table class="table table-pycon">
+		<thead>
+			<tr>
+				<th class="text-emphasize">尺寸</th>
+				<th>XS</th>
+				<th>S</th>
+				<th>M</th>
+				<th>L</th>
+				<th>XL</th>
+				<th>2XL</th>
+				<th>3XL</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td class="text-emphasize">身高（cm）</td>
+				<td>150 以下</td>
+				<td>150–160</td>
+				<td>160–170</td>
+				<td>170–180</td>
+				<td colspan="3">180 以上</td>
+			</tr>
+			<tr>
+				<td class="text-emphasize">胸寬（cm）</td>
+				<td>44.5</td>
+				<td>47</td>
+				<td>49.5</td>
+				<td>52</td>
+				<td>54.5</td>
+				<td>57</td>
+				<td>59.5</td>
+			</tr>
+			<tr>
+				<td class="text-emphasize">衣長（cm）</td>
+				<td>62</td>
+				<td>63.5</td>
+				<td>66</td>
+				<td>68.5</td>
+				<td>71</td>
+				<td>73.5</td>
+				<td>73.5</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
 
-    <table class="table table-pycon">
-        <tbody>
-        <tr>
-            <th class='text-emphasize' colspan="1" rowspan="1">
-               尺寸
-            </th>
-            <th colspan="1" rowspan="1">
-               XS
-            </th>
-            <th colspan="1" rowspan="1">
-               S
-            </th>
-            <th colspan="1" rowspan="1">
-               M
-            </th>
-            <th colspan="1" rowspan="1">
-               L
-            </th>
-            <th colspan="1" rowspan="1">
-               XL
-            </th>
-            <th colspan="1" rowspan="1">
-               2XL
-            </th>
-            <th colspan="1" rowspan="1">
-               3XL
-            </th>
-        </tr>
-        <tr>
-            <td class='text-emphasize' colspan="1" rowspan="1">
-               身高 (cm)
-            </td>
-            <td colspan="1" rowspan="1">
-               150&nbsp;以下
-            </td>
-            <td colspan="1" rowspan="1">
-               150~160
-            </td>
-            <td colspan="1" rowspan="1">
-               160~170
-            </td>
-            <td colspan="1" rowspan="1">
-               170~180
-            </td>
-            <td colspan="3" rowspan="1">
-               180以上
-            </td>
-        </tr>
-        <tr>
-            <td class='text-emphasize' colspan="1" rowspan="1">
-               胸寬 (cm)
-            </td>
-            <td colspan="1" rowspan="1">
-               44.5
-            </td>
-            <td colspan="1" rowspan="1">
-               47
-            </td>
-            <td colspan="1" rowspan="1">
-               49.5
-            </td>
-            <td colspan="1" rowspan="1">
-               52
-            </td>
-            <td colspan="1" rowspan="1">
-               54.5
-            </td>
-            <td colspan="1" rowspan="1">
-               57
-            </td>
-            <td colspan="1" rowspan="1">
-               59.5
-            </td>
-        </tr>
-        <tr>
-            <td class='text-emphasize' colspan="1" rowspan="1">
-               衣長 (cm)
-            </td>
-            <td colspan="1" rowspan="1">
-               62
-            </td>
-            <td colspan="1" rowspan="1">
-               63.5
-            </td>
-            <td colspan="1" rowspan="1">
-               66
-            </td>
-            <td colspan="1" rowspan="1">
-               68.5
-            </td>
-            <td colspan="1" rowspan="1">
-               71
-            </td>
-            <td colspan="1" rowspan="1">
-               73.5
-            </td>
-            <td colspan="1" rowspan="1">
-               73.5
-            </td>
-        </tr>
-        </tbody>
-    </table>
-    </div>
-
-    <h4>2. Everybody Pays</h4>
-    <p>
-        PyCon Taiwan 2016 是需付費的活動，所有籌備人員和講者均自行付費參加。見
-        (<a href="https://tw.pycon.org/2013/zh/blog/2013/03/05/everybody-pays-zh/">
-            公平付費
-        </a>）
-    </p>
+<h4>2. Everybody Pays</h4>
+<p>
+	PyCon Taiwan 2016 是需付費的活動，所有籌備人員和講者均自行付費參加。見<a href="https://tw.pycon.org/2013/zh/blog/2013/03/05/everybody-pays-zh/">公平付費</a>。
+</p>
 
 
-    <h4>3. 付款方式</h4>
-    <p>我們提供三種付款方式：信用卡、PayPal、ATM轉帳。</p>
+<h4>3. 付款方式</h4>
+<p>我們提供三種付款方式：信用卡、PayPal、ATM 轉帳。</p>
 
 
-    <h4>4. 不接受退票</h4>
-    <p>本次活動恕不受理退票。僅受理補差額更改優惠票成一般票，須於售票截止前 (2016 年 5 月 13 日) 寄信至 registration[at]pycon.tw 告知，活動方將於更改完成後，寄信通知買方。</p>
+<h4>4. 不接受退票</h4>
+<p>本次活動恕不受理退票。僅受理補差額更改優惠票成一般票，須於售票截止前 (2016 年 5 月 13 日) 寄信至 registration[at]pycon.tw 告知，活動方將於更改完成後，寄信通知買方。</p>
 
 
-    <h4>5. 財務補助計畫 Financial Aid Plan</h4>
-
-    <p>若您資金上有困難，歡迎申請大會 Financial Aid 計劃，但必須先購票才能申請！ 更多的申請說明請至該
-        <a href="{{ reg_financial_aid_url }}">
-            專頁
-        </a>。
-    </p>
+<h4>5. 財務補助計畫（Financial Aid Plan）</h4>
+<p>若您資金上有困難，歡迎申請大會 Financial Aid 計劃，但必須先購票才能申請！ 更多的申請說明請至該<a href="{{ reg_financial_aid_url }}">專頁</a>。
+</p>
 
 
-    <h4>6. 特殊飲食習慣</h4>
-    <p>會議當天提供午餐，素食或其他需求（例如：不吃牛肉或豬肉）請務必註明。</p>
+<h4>6. 飲食需求</h4>
+<p>會議當天提供午餐。請務必註明您的飲食需求。</p>
 
 
-    <h4>
-        7. 正確的聯絡資訊
-    </h4>
-    <p>
-        報名時請留下正確的聯絡方式（手機號碼與 email），以便大會通知。
-    </p>
+<h4>7. 正確的聯絡資訊</h4>
+<p>報名時請留下正確的聯絡方式（手機號碼與 email），以便大會通知。</p>
 
 
-    <h4>8. 票務諮詢管道</h4>
-    <p>如有任何問題，請寄信至 registration[at]pycon.tw 洽詢，我們將盡快給予回應。</p>
+<h4>8. 票務諮詢管道</h4>
+<p>如有任何問題，請寄信至 registration[at]pycon.tw 洽詢，我們將盡快給予回應。</p>
 
-    <h4>9. 關於PyCon 課程 (Tutorial)、PyDay</h4>
+<h4>9. 關於 PyCon 課程 (Tutorial)、PyDay</h4>
 
-    <p>您可以透過本頁面最上方 [活動] 下拉選單，查詢 PyCon 課程 (待公告)、<a href="{{ events_sprints_url }}">Sprints</a> 以及 <a href="{{ events_pyday_url }}">PyDay</a>
-       相關內容。</p>
+<p>您可以透過本頁面最上方「活動」下拉選單，查詢 PyCon 課程 (待公告)、<a href="{{ events_sprints_url }}">Sprints</a> 以及 <a href="{{ events_pyday_url }}">PyDay</a>
+   相關內容。</p>
 
-    <p>歡迎所有 Python 愛好者的參加與宣傳，期待在 PyCon Taiwan 2016 會場與您相見 :)</p>
+<hr>
+
+<p>歡迎所有 Python 愛好者的參加與宣傳，期待在 PyCon Taiwan 2016 會場與您相見 :)</p>
 
 
 {% endblock %}


### PR DESCRIPTION
內容以中文版為主，所以中文的文案只有小修一點，主要是飲食需求那段。

結構上的修改：

1. 我把一般票統一放到最上面了，總之以中文版為主。
2. Table 的標題列放到 `thead`，CSS 也相應修改。

我把日期格式也統一了。