### PR TITLE
Add a little margin between speaker photo and bio

### DIFF
--- a/src/static/css/pages/_front.scss
+++ b/src/static/css/pages/_front.scss
@@ -148,6 +148,10 @@
             .speaker-photo {
                 width: 100%;
                 max-width: 260px;
+
+                @media (max-width: $screen-xs-max) {
+                    margin-bottom: 2em;
+                }
             }
         }
     }


### PR DESCRIPTION
<table>
<thead>
<tr><th>Before</th><th>After</th>
</thead>
<tbody>
<tr><td><img src="https://cloud.githubusercontent.com/assets/605277/14845904/a200ee1e-0c93-11e6-8741-11d6df4a3cb1.png"></td><td><img src="https://cloud.githubusercontent.com/assets/605277/14845911/ac94ad5c-0c93-11e6-9b91-4fab3bbd6ec9.png"></td></tr>
</tbody>
</table>