### PR TITLE
在 admin 與公開介面使用不同的 user creation form

### DIFF
--- a/src/users/tests/test_forms.py
+++ b/src/users/tests/test_forms.py
@@ -2,13 +2,15 @@ import pytest
 
 from crispy_forms.helper import FormHelper
 
-from users.forms import PasswordResetForm, SetPasswordForm, UserCreationForm
+from users.forms import (
+    PasswordResetForm, PublicUserCreationForm, SetPasswordForm,
+)
 
 
 @pytest.mark.parametrize('form_class,kwarg_keys', [
-    (PasswordResetForm, []),
-    (SetPasswordForm,   ['user']),
-    (UserCreationForm,  []),
+    (PasswordResetForm,      []),
+    (SetPasswordForm,        ['user']),
+    (PublicUserCreationForm, []),
 ])
 def test_form_helper(user, form_class, kwarg_keys):
     locs = locals()

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -15,7 +15,7 @@ from django.views.decorators.http import require_POST
 
 from .decorators import login_forbidden
 from .forms import (
-    AuthenticationForm, UserCreationForm, UserProfileUpdateForm,
+    AuthenticationForm, PublicUserCreationForm, UserProfileUpdateForm,
     PasswordResetForm, SetPasswordForm,
 )
 
@@ -28,7 +28,7 @@ User = get_user_model()
 @login_forbidden
 def user_signup(request):
     if request.method == 'POST':
-        form = UserCreationForm(data=request.POST)
+        form = PublicUserCreationForm(data=request.POST)
         if form.is_valid():
             user = form.save()
             user.send_verification_email(request)
@@ -39,7 +39,7 @@ def user_signup(request):
             ))
             return redirect('user_dashboard')
     else:
-        form = UserCreationForm()
+        form = PublicUserCreationForm()
     return render(request, 'registration/signup.html', {'form': form})
 
 


### PR DESCRIPTION
原本的 `UserCreationForm` 無法用在 admin，所以把一些功能拆到 `PublicUserCreationForm`（公開介面改用這個），讓 admin 可以使用前者。