### PR TITLE
Add gdoc preview version of the program schedule

### DIFF
--- a/src/templates/events/talk_list.html
+++ b/src/templates/events/talk_list.html
@@ -9,6 +9,22 @@
 {% block content %}
 
 {% if object_list %}
+
+<div class="pycon-list">
+	<div class="pycon-list-item text-theme-highlight">
+		{% blocktrans trimmed with gdoc_url="https://docs.google.com/spreadsheets/d/17-8E1OhfgiG4pIOIrp3OpNY4OaK1QxUn4TJK9oVmRSw/htmlview" %}
+		You can peek the program schedule on
+		<a class="text-emphasize" href="{{ gdoc_url }}" target="_blank">this Google document</a>.
+		{% endblocktrans %}
+	</div>
+	<div class="pycon-list-item text-theme-highlight">
+		{% blocktrans trimmed %}
+		Program schedule <span class="text-emphasize">may be subject to change</span>.
+		Please check this page frequently to get the latest version.
+		{% endblocktrans %}
+	</div>
+</div>
+
 <h2>{% trans 'Proposed Talks' %}</h2>
 <ul class="talk-list">
 	{% for proposal in object_list %}

--- a/src/templates/events/talk_list.html
+++ b/src/templates/events/talk_list.html
@@ -13,13 +13,13 @@
 <div class="pycon-list">
 	<div class="pycon-list-item text-theme-highlight">
 		{% blocktrans trimmed with gdoc_url="https://docs.google.com/spreadsheets/d/17-8E1OhfgiG4pIOIrp3OpNY4OaK1QxUn4TJK9oVmRSw/htmlview" %}
-		You can peek the program schedule on
+		You can peek at the program schedule on
 		<a class="text-emphasize" href="{{ gdoc_url }}" target="_blank">this Google document</a>.
 		{% endblocktrans %}
 	</div>
 	<div class="pycon-list-item text-theme-highlight">
 		{% blocktrans trimmed %}
-		Program schedule <span class="text-emphasize">may be subject to change</span>.
+		Program schedule are <span class="text-emphasize">subject to change</span>.
 		Please check this page frequently to get the latest version.
 		{% endblocktrans %}
 	</div>


### PR DESCRIPTION
Quick hack. So the team can have more time refine the work.
![screen shot 2016-05-01 at 11 29 11 pm](https://cloud.githubusercontent.com/assets/1544283/14942629/e189d8ac-0ff4-11e6-8c9a-b4eb2993bf30.png)

Google doc looks like the following,
![screen shot 2016-05-01 at 11 32 45 pm](https://cloud.githubusercontent.com/assets/1544283/14942636/091b82f8-0ff5-11e6-83bf-8189af0cc99c.png)

I didn't use orange because it is a bit harder to read, probably due to the font.
