### PR TITLE
Add edit link in detail pages

### DIFF
--- a/src/static/css/_bootstrap-variables.scss
+++ b/src/static/css/_bootstrap-variables.scss
@@ -14,7 +14,7 @@ $gray-dark:              lighten($gray-base, 20%) !default;   // #333
 $gray:                   lighten($gray-base, 33.5%) !default; // #555
 $gray-light:             lighten($gray-base, 46.7%) !default; // #777
 $gray-lighterish:        lighten($gray-base, 80%) !default;
-// $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
+$gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
 
 // $brand-primary:         darken(#428bca, 6.5%) !default; // #337ab7
 // $brand-success:         #5cb85c !default;

--- a/src/static/css/pages/_front.scss
+++ b/src/static/css/pages/_front.scss
@@ -10,8 +10,24 @@
     color: white;
 
     h1 {
+
         padding: 52px 0 22px;
         font-size: 40px;
+
+        .accessory {
+
+            margin-left: 0.5em;
+            font-size: 60%;
+
+            > a {
+                margin-left: 5px;
+                color: $gray-lighterish;
+
+                &:hover, &:focus {
+                    color: $gray-lighter;
+                }
+            }
+        }
     }
 }
 

--- a/src/templates/events/sponsored_event_detail.html
+++ b/src/templates/events/sponsored_event_detail.html
@@ -60,6 +60,11 @@
 				<span class="fa fa-facebook" aria-hidden="true"></span>
 			</a>
 			{% endif %}
+			{% if user == request.user %}
+			<a href="{% url 'user_profile_update' %}" target="_blank">
+				<span class="fa fa-edit" aria-hidden="true"></span>
+			</a>
+			{% endif %}
 		</span>
 	</h3>
 	<div class="row">

--- a/src/templates/events/talk_detail.html
+++ b/src/templates/events/talk_detail.html
@@ -5,7 +5,18 @@
 
 {% block title %}{{ object.title }}{% endblock title %}
 
-{% block page_title %}<h1>{{ object.title }}</h1>{% endblock page_title %}
+{% block page_title %}
+<h1>
+	{{ object.title }}
+	{% if object.submitter == user %}
+	<span class="accessory">
+		<a href="{% url 'talk_proposal_update' pk=object.pk %}" target="_blank">
+			<span class="fa fa-edit" aria-hidden="true"></span>
+		</a>
+	</span>
+	{% endif %}
+</h1>
+{% endblock page_title %}
 
 
 {% block content_page_class %}{{ block.super }} talk-detail-content{% endblock content_page_class %}
@@ -59,6 +70,11 @@
 			{% if user.facebook_profile_url %}
 			<a href="{{ user.facebook_profile_url }}" target="_blank">
 				<span class="fa fa-facebook" aria-hidden="true"></span>
+			</a>
+			{% endif %}
+			{% if user == request.user %}
+			<a href="{% url 'user_profile_update' %}" target="_blank">
+				<span class="fa fa-edit" aria-hidden="true"></span>
 			</a>
 			{% endif %}
 		</span>


### PR DESCRIPTION
Fix #242.

除了 proposal 修改連結外，同時也在 speaker info 那邊加了修改的連結，連到 profile update page。目前是用一個 icon，好像有一點突兀⋯⋯請評論。