### PR TITLE
把 ORM 邏輯移出 .speakers property

### DIFF
--- a/src/events/views.py
+++ b/src/events/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.urlresolvers import reverse
+from django.db.models import Prefetch
 from django.http import Http404, HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import (
@@ -7,7 +8,7 @@ from django.views.generic import (
 )
 
 from core.mixins import FormValidMessageMixin
-from proposals.models import TalkProposal
+from proposals.models import TalkProposal, AdditionalSpeaker
 
 from .forms import ScheduleCreationForm
 from .models import Schedule, SponsoredEvent
@@ -19,6 +20,10 @@ class AcceptedTalkMixin:
         TalkProposal.objects
         .filter_accepted()
         .select_related('submitter')
+        .prefetch_related(Prefetch(
+            lookup='additionalspeaker_set',
+            queryset=AdditionalSpeaker.objects.select_related('user'),
+        ))
         .order_by('title')
     )
 

--- a/src/proposals/models.py
+++ b/src/proposals/models.py
@@ -170,9 +170,13 @@ class AbstractProposal(EventInfo):
     @property
     def speakers(self):
         yield PrimarySpeaker(proposal=self)
-        additionals = self.additionalspeaker_set.filter(cancelled=False)
-        for speaker in additionals.select_related('user'):
-            yield speaker
+        # We filter cancelled speakers in Python instead of ORM to make sure
+        # the additionalspeaker_set query can be prefetched. This is the
+        # right trade-off because it's unlikely there are a lot of cancelled
+        # additional speakers, so this overhead is very small.
+        for speaker in self.additionalspeaker_set.all():
+            if not speaker.cancelled:
+                yield speaker
 
     @property
     def speaker_count(self):

--- a/src/proposals/views/speakers.py
+++ b/src/proposals/views/speakers.py
@@ -25,7 +25,10 @@ class ProposalManageSpeakersView(
     def get_proposal(self):
         try:
             proposal = (
-                self.proposal_model.objects.select_related('submitter').get(
+                self.proposal_model.objects
+                .select_related('submitter')
+                .prefetch_related('additionalspeaker_set__user')
+                .get(
                     pk=self.kwargs['pk'],
                     submitter=self.request.user,
                     cancelled=False,


### PR DESCRIPTION
主要因為是現在的 talk list 頁面需要 prefetch 講者資訊，但 speakers property 裡面的邏輯會讓它壞掉。

現在這個版本應該可以看到 talk list 頁面的 query 數有顯著下降（實際下降多少視有多少 additional speakers 而定）。我把原本該有的 select/prefetch related 加回有用到那個 property 的地方了，所以應該不會對原本的程式有影響（有個很小的例外，我寫在註解裡）。
