### PR TITLE
改寫 Markdown → HTML 函式

### DIFF
--- a/src/static/js/tools/simplemde-setup.js
+++ b/src/static/js/tools/simplemde-setup.js
@@ -20,18 +20,14 @@ for (var i = 0; i < elementList.length; i++) {
 
 (function (SimpleMDE) {
 
-if (!document.querySelectorAll || !window.DOMParser)
+if (!document.querySelectorAll)
 	return;
-
-var parser = new DOMParser();
 
 var elementList = document.querySelectorAll(
 	'.editor-readonly > .editor-preview');
-for (var i = 0; i < elementList.length; i++) {
-	var element = elementList[i];
-	var source = element.textContent || element.innerText;
-	element.innerHTML = SimpleMDE.prototype.markdown(
-		parser.parseFromString(source, 'text/html').documentElement.textContent);
-}
+Array.prototype.forEach.call(elementList, function (e) {
+	var source = e.textContent || e.innerText;
+	e.innerHTML = SimpleMDE.prototype.markdown(source);
+});
 
 })(SimpleMDE);


### PR DESCRIPTION
原本的版本沒辦法處理 inline HTML (全部 tag 會被移除)，現在這個版本可以。順便用 `Array.prototype.forEach` 讓程式漂亮一點。

剛剛在看投影片發現的。應該是沒有實際的顯示問題。
