### PR TITLE
Upgrade to Django 1.10.4.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Django
 # https://www.djangoproject.com/
-Django==1.9.3
+Django==1.10.4
 
 # Reusable mixins for Django
 # http://django-braces.readthedocs.org/en/latest/index.html
@@ -12,7 +12,7 @@ django-compressor==1.6
 
 # The best way to have DRY Django forms.
 # http://django-crispy-forms.readthedocs.org/en/latest/
-django-crispy-forms==1.5.2
+django-crispy-forms==1.6.1
 
 # Django-environ allows you to utilize 12factor inspired environment variables
 # to configure your Django application.
@@ -29,7 +29,7 @@ django-libsass==0.6
 
 # Translates Django models using a registration approach.
 # https://github.com/deschler/django-modeltranslation
-django-modeltranslation==0.11
+django-modeltranslation==0.12
 
 # Certifi, a carefully curated collection of Root Certificates for SSL
 certifi>=2015.11.20

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,11 +3,11 @@
 # A configurable set of panels that display various debug information about
 # the current request/response.
 # http://django-debug-toolbar.readthedocs.org/
-django-debug-toolbar==1.4
+django-debug-toolbar==1.6
 
 # The Python WSGI Utility Library
 # http://werkzeug.pocoo.org/
-Werkzeug==0.11.3
+Werkzeug==0.11.11
 
 # A mature full-featured Python testing tool
 # http://pytest.org/latest/

--- a/src/core/middlewares.py
+++ b/src/core/middlewares.py
@@ -3,6 +3,8 @@ import re
 from django.conf import settings
 from django.core.urlresolvers import get_script_prefix
 from django.http import HttpResponseRedirect
+from django.utils.deprecation import MiddlewareMixin
+
 
 
 # Matches things like
@@ -20,11 +22,17 @@ FALLBACK_PREFIX_PATTERN = re.compile(
 )
 
 
-class LocaleFallbackMiddleware:
+class LocaleFallbackMiddleware(object):
     """Redirect entries in ``settings.FALLBACK_LANGUAGE_PREFIXES`` to a
     valid language prefix.
     """
     response_redirect_class = HttpResponseRedirect
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.process_request(request) or self.get_response(request)
 
     def process_request(self, request):
         if not settings.USE_I18N:

--- a/src/pycontw2016/settings/base.py
+++ b/src/pycontw2016/settings/base.py
@@ -36,7 +36,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
-                'django.core.context_processors.request',
+                'django.template.context_processors.request',
                 'core.context_processors.google_analytics',
                 'core.context_processors.proposals_states',
             ],
@@ -107,7 +107,7 @@ if 'postgres' in DATABASES['default']['ENGINE']:
     INSTALLED_APPS += ('postgres',)
 
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'core.middlewares.LocaleFallbackMiddleware',
@@ -118,6 +118,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
 ROOT_URLCONF = 'pycontw2016.urls'

--- a/src/pycontw2016/settings/local.py
+++ b/src/pycontw2016/settings/local.py
@@ -11,7 +11,7 @@ if 'celery' in sys.argv[0]:
     DEBUG = False
 
 # Django Debug Toolbar
-INSTALLED_APPS += ('debug_toolbar.apps.DebugToolbarConfig',)
+INSTALLED_APPS += ('debug_toolbar',)
 
 # Install local, development apps.
 INSTALLED_APPS += env.tuple('LOCAL_APPS', default=())


### PR DESCRIPTION
Upgrade Django version to 1.10.4. Some packages are also upgraded to
support newer version of Django.

`LocaleFallbackMiddleware` is also modified to new style middleware
introduced in Django 1.10.