### PR TITLE
Add `active` to context in `IndexView`.

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -21,6 +21,9 @@ class IndexView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        context['active'] = None
+
         deadline = datetime(2016, 6, 3, 8, 20)
         now = timezone.now()
         countdown = pytz.timezone('Asia/Taipei').localize(deadline) - now


### PR DESCRIPTION
Fix `active` not being in the context.

Should fix Issue #283.