### PR TITLE
Add Django Debug Toolbar configurations.

### DIFF
--- a/src/pycontw2016/settings/local.py
+++ b/src/pycontw2016/settings/local.py
@@ -5,6 +5,8 @@ import logging.config
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+INTERNAL_IPS = ['127.0.0.1']
+
 # Turn off debug while imported by Celery with a workaround
 # See http://stackoverflow.com/a/4806384
 if 'celery' in sys.argv[0]:

--- a/src/pycontw2016/urls.py
+++ b/src/pycontw2016/urls.py
@@ -36,3 +36,11 @@ urlpatterns += [
 
 # User-uploaded files like profile pics need to be served in development.
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Debug Toolbar's URL.
+# See http://django-debug-toolbar.readthedocs.io/en/stable/installation.html#urlconf
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]


### PR DESCRIPTION
Add `INTERNAL_IPS` settings and URLconf for Django Debug Toolbar.

I forgot to include these settings in PR #282. 