### PR TITLE
modify talk short duration to 30min

### DIFF
--- a/src/proposals/models.py
+++ b/src/proposals/models.py
@@ -225,7 +225,7 @@ class TalkProposal(AbstractProposal):
             "How the talk will be arranged. It is highly recommended to "
             "attach the estimated time length for each sections in the talk. "
             "Talks in favor of 45min should have a fallback plan about how "
-            "to shrink the content into a 25min one. Edit using "
+            "to shrink the content into a 30min one. Edit using "
             "<a href='http://daringfireball.net/projects/markdown/basics' "
             "target='_blank'>Markdown</a>."
             "This is NOT made public and for REVIEW ONLY."


### PR DESCRIPTION
 剛剛發現 `proposal/modal.py` 內的 30min 演講長度沒改到。