### PR TITLE
Show hint if there is a redacted review comment

### DIFF
--- a/src/static/css/pages/_proposals.scss
+++ b/src/static/css/pages/_proposals.scss
@@ -172,6 +172,9 @@ body.dashboard{
                 .comment-display {
                     text-align: left;
                 }
+                .text-muted {
+                    color: #aaa;
+                }
             }
         }
     }

--- a/src/templates/default/reviews/_includes/previous_review_table.html
+++ b/src/templates/default/reviews/_includes/previous_review_table.html
@@ -19,7 +19,7 @@
 				{% if show_all_comments or review.is_comment_visible_to_submitter %}
 				{{ review.comment|linebreaks }}
 				{% elif review.comment %}
-				<span class="text-danger">{% trans 'Comment redacted by the reviewer or organizers.' %}</span>
+				<span class="text-muted">{% trans '(Comment redacted by the reviewer or organizers.)' %}</span>
 				{% endif %}
 			</td>
 		</tr>

--- a/src/templates/default/reviews/_includes/previous_review_table.html
+++ b/src/templates/default/reviews/_includes/previous_review_table.html
@@ -18,6 +18,8 @@
 			<td class="comment-display">
 				{% if show_all_comments or review.is_comment_visible_to_submitter %}
 				{{ review.comment|linebreaks }}
+				{% elif review.comment %}
+				<span class="text-danger">{% trans 'Comment redacted by the reviewer or organizers.' %}</span>
 				{% endif %}
 			</td>
 		</tr>


### PR DESCRIPTION
如果 reviewer 有留言，只是被隱藏，顯示一個提示訊息（而不是空白）。這樣投稿人看起來會比較合理（會知道是留言被隱藏，而不是 reviewer 評分卻不寫為什麼）。